### PR TITLE
Add TutorialSearch to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
   - [Fetching Data using GraphQL Queries with Angular & Apollo Tutorial](https://www.howtographql.com/angular-apollo/2-queries-loading-links)
   - [(Video) Using GraphQL with Angular](https://www.youtube.com/watch?v=-ONW7mDg0-o)
   - [(Video) Faster modern apps with Angular and GraphQL](https://www.youtube.com/watch?v=Xx39bv-5ojA)
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ## Boilerplates and Example Apps
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
   - [Fetching Data using GraphQL Queries with Angular & Apollo Tutorial](https://www.howtographql.com/angular-apollo/2-queries-loading-links)
   - [(Video) Using GraphQL with Angular](https://www.youtube.com/watch?v=-ONW7mDg0-o)
   - [(Video) Faster modern apps with Angular and GraphQL](https://www.youtube.com/watch?v=Xx39bv-5ojA)
-- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+- [TutorialSearch](https://tutorialsearch.io/browse/web-development/angular-development) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ## Boilerplates and Example Apps
 


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Tutorials* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/web-development/angular-development) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/web-development/angular-development) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.